### PR TITLE
Update miniz.c

### DIFF
--- a/minizip/miniz.c
+++ b/minizip/miniz.c
@@ -3100,7 +3100,7 @@ static int mz_stat64(const char *path, struct __stat64 *buffer)
 #define MZ_FFLUSH fflush
 #define MZ_FREOPEN(f, m, s) freopen(f, m, s)
 #define MZ_DELETE_FILE remove
-#elif defined(__USE_LARGEFILE64) /* gcc, clang */
+#elif defined(__USE_LARGEFILE64) && !defined(__APPLE__) /* gcc, clang */
 #ifndef MINIZ_NO_TIME
 #include <utime.h>
 #endif


### PR DESCRIPTION
Even with gcc/clang - on apple we shouldn't use fopen64 etc as they don't exist.

Was getting compile errors on a mac in somalier and slivar - and this seems to be the core fix. Once done, slivar seems to now compile and run on my os x machine
